### PR TITLE
Prevent survivor from picking up too many items

### DIFF
--- a/python/test/test_survivor.py
+++ b/python/test/test_survivor.py
@@ -1,4 +1,6 @@
-from zombie_survivor.survivor import Survivor, EQUIPMENT_LIMIT
+import pytest
+
+from zombie_survivor.survivor import Survivor, NoSpaceRemainingError, EQUIPMENT_LIMIT
 
 
 class TestSurvivor:
@@ -20,6 +22,12 @@ class TestSurvivor:
         expected_space_remaining = self.survivor.space_remaining - 1
         self.survivor.pick_up('baseball bat')
         assert self.survivor.space_remaining == expected_space_remaining
+    
+    def test_can_not_pick_up_too_much_equipment(self):
+        for _ in range(EQUIPMENT_LIMIT):
+            self.survivor.pick_up('baseball bat')
+        with pytest.raises(NoSpaceRemainingError):
+            self.survivor.pick_up('baseball bat')
     
     def test_can_be_wounded(self):
         expected_wound_count = self.survivor.wound_count + 1

--- a/python/zombie_survivor/survivor.py
+++ b/python/zombie_survivor/survivor.py
@@ -1,5 +1,8 @@
 EQUIPMENT_LIMIT = 5
 
+class NoSpaceRemainingError(Exception):
+    pass
+
 class Survivor:
     def __init__(self, name: str):
         self.name = name
@@ -26,7 +29,12 @@ class Survivor:
     def wound_count(self) -> int:
         return self._wound_count
 
+    def has_space_remaining(self) -> bool:
+        return self.space_remaining > 0
+
     def pick_up(self, item: str):
+        if not self.has_space_remaining():
+            raise NoSpaceRemainingError
         self._equipment.append(item)
 
     def wound(self):


### PR DESCRIPTION
## Summary

Currently, our `Survivor` can pick up an infinite number of items. There is no limit check or guard statement in the `pick_up()` function. This PR closes that loophole and raises a `NoSpaceRemainingError` once the survivor has reached the limit on the number of equipment they can carry.